### PR TITLE
Fix paths only emitting a single backslash for Windows in the demo codegen

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -70,8 +70,8 @@ fn include_config<P, Q>(files_dir: P, codegen_fname: Q) -> Result<(), Box<Error>
     writeln!(f, "fn get_default_config() -> Config {{")?;
     writeln!(f, "    Config {{")?;
     writeln!(f,
-             "        serve_filepath: std::path::Path::new(\"{}/\"),",
-             files_dir.as_ref().display())?;
+             "        serve_filepath: std::path::Path::new({:?}),",
+             files_dir.as_ref())?;
     #[cfg(feature = "bundle_files")]
     {
         writeln!(f, "        bundled_files: &PUBLIC,")?;


### PR DESCRIPTION
Hey there! Windows user here who ran into this issue when trying to see the example `frontend_yew`. :)

On Windows, the path separator is `\` -- which turns into an escape when placed into a string literal. For instance, in my case this would turn paths into `"frontend_yew\dist/"`, which would spit out the following compilation error:

```
~/…/bui-backend/bui-demo master$ cargo run --no-default-features --features "serve_files frontend_yew"
...
error: unknown character escape: d
 --> ...\bui-backend\target\debug\build\bui-demo-e895244f9e0b0f7c\out/public.rs:4:60
  |
4 |         serve_filepath: std::path::Path::new("frontend_yew\dist/"),
  |                                                            ^

error: aborting due to previous error

error: Could not compile `bui-demo`.

To learn more, run the command again with --verbose.
```

I've changed the path codegen to use `Debug` without explicit quotes since, AFAIK, always produces a string that can simply be pasted and treated as code.