### PR TITLE
codegen uses raw string literals

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -70,7 +70,7 @@ fn include_config<P, Q>(files_dir: P, codegen_fname: Q) -> Result<(), Box<Error>
     writeln!(f, "fn get_default_config() -> Config {{")?;
     writeln!(f, "    Config {{")?;
     writeln!(f,
-             "        serve_filepath: std::path::Path::new(\"{}/\"),",
+             "        serve_filepath: std::path::Path::new(r#\"{}\"#),",
              files_dir.as_ref().display())?;
     #[cfg(feature = "bundle_files")]
     {


### PR DESCRIPTION
This avoids backslash in Windows path being interpreted as escape
sequence.

Fixes #2.